### PR TITLE
Add support for single character input names

### DIFF
--- a/lib/phoenix_integration/requests.ex
+++ b/lib/phoenix_integration/requests.ex
@@ -1139,7 +1139,7 @@ defmodule PhoenixIntegration.Requests do
 
   # ----------------------------------------------------------------------------'
   defp build_named_value(name, value) do
-    case Regex.scan(~r/\w+[\w+]/, name) do
+    case Regex.scan(~r/\w+/, name) do
       [[key]] ->
         {:ok, %{String.to_atom(key) => value}}
 

--- a/test/fixtures/templates/sample.html
+++ b/test/fixtures/templates/sample.html
@@ -291,6 +291,10 @@ A proper one this time, with fields to be filled out.
     </select>
   </div>
 
+  <input type="checkbox" name="user[grades][a]" value="true" checked="false">  A<br>
+  <input type="checkbox" name="user[grades][b]" value="true" checked="false">  B<br>
+  <input type="checkbox" name="user[grades][c]" value="true" checked="false">  C<br>
+
   <div class="form-group">
     <input class="btn btn-primary" type="submit" value="Update">
   </div>

--- a/test/request_test.exs
+++ b/test/request_test.exs
@@ -198,7 +198,9 @@ defmodule PhoenixIntegration.RequestTest do
 
   test "submit_form works", %{conn: conn} do
     get(conn, "/sample")
-    |> submit_form(%{user: %{name: "Fine Name"}}, %{identifier: "#proper_form"})
+    |> submit_form(%{user: %{name: "Fine Name", grades: %{a: "true", b: "false"}}}, %{
+      identifier: "#proper_form"
+    })
     |> assert_response(status: 302, to: "/second")
   end
 
@@ -254,8 +256,6 @@ defmodule PhoenixIntegration.RequestTest do
     |> follow_form(%{user: %{usage: "moderate", locale: "rural"}}, identifier: "#proper_form")
     |> assert_response(status: 200, path: "/second")
   end
-
-
 
   # ============================================================================
   # fetch_form


### PR DESCRIPTION
Hi there, this PR adds support for single character input names.

We have a case in our test suite where we need to associate a bunch of ids to a model. The fields look something like this

```html
<input type=checkbox name=child_model[1] value=false checked=false>
<input type=checkbox name=child_model[2] value=false checked=false>
<input type=checkbox name=child_model[3] value=false checked=false>
```

And the code for submitting the form looks like the following

```elixir
conn
|> submit_form(%{child_model: %{"1": "true", "2": "true"}})
```

which is causing the following error:

```elixir
     ** (BadMapError) expected a map, got: "true"
     code: |> submit_form(%{child_model: %{"1": "true", "2": "true"}})
     stacktrace:
       (stdlib) :maps.is_key(:"1", "true")
       (phoenix_integration) lib/phoenix_integration/requests.ex:1088: PhoenixIntegration.Requests.put_if_available!/4
       (stdlib) lists.erl:1263: :lists.foldl/3
       (phoenix_integration) lib/phoenix_integration/requests.ex:1077: anonymous fn/3 in PhoenixIntegration.Requests.merge_grouped_fields/3
       (stdlib) lists.erl:1263: :lists.foldl/3
       (phoenix_integration) lib/phoenix_integration/requests.ex:1077: anonymous fn/3 in PhoenixIntegration.Requests.merge_grouped_fields/3
       (stdlib) lists.erl:1263: :lists.foldl/3
       (phoenix_integration) lib/phoenix_integration/requests.ex:444: PhoenixIntegration.Requests.submit_form/3
       test/request_test.exs:201: (test)
```

The fix is simple enough and the suite is still green. I'm not sure if I've missed some corner cases though. Also, the test example is a bit contrived but I think it still expresses what is going on. 

Cheers,