### PR TITLE
Support deeply nested form fields

### DIFF
--- a/lib/phoenix_integration/requests.ex
+++ b/lib/phoenix_integration/requests.ex
@@ -1140,23 +1140,20 @@ defmodule PhoenixIntegration.Requests do
   # ----------------------------------------------------------------------------'
   defp build_named_value(name, value) do
     case Regex.scan(~r/\w+/, name) do
-      [[key]] ->
-        {:ok, %{String.to_atom(key) => value}}
-
-      [[key], [sub_key]] ->
-        {:ok, %{String.to_atom(key) => %{String.to_atom(sub_key) => value}}}
-
-      [[key], [sub_key], [sub_sub_key]] ->
-        {:ok,
-         %{
-           String.to_atom(key) => %{
-             String.to_atom(sub_key) => %{String.to_atom(sub_sub_key) => value}
-           }
-         }}
-
-      _ ->
+      [] ->
         {:error, :unknown_format}
+
+      keys ->
+        {:ok, nested_value(keys, value)}
     end
+  end
+
+  defp nested_value([[key] | keys], value) do
+    %{String.to_atom(key) => nested_value(keys, value)}
+  end
+
+  defp nested_value([], value) do
+    value
   end
 
   defp is_struct(v) do

--- a/test/fixtures/templates/sample.html
+++ b/test/fixtures/templates/sample.html
@@ -134,6 +134,11 @@ A proper one this time, with fields to be filled out.
     <input id="user_tag_name" name="user[tag][name]" type="text" value="tag">
   </div>
 
+  A deeply nested form field
+  <div class="form-group">
+    <input name="user[friends][0][address][city][zip]" type="text" value="12345">
+  </div>
+
   A datetime select
   <div class="form-group">
     <label for="user_joined_at">Joined at</label>

--- a/test/forms_test.exs
+++ b/test/forms_test.exs
@@ -130,9 +130,16 @@ defmodule PhoenixIntegration.FormsTest do
     assert user_params.species == "narn"
   end
 
-  test "build form dataa sets nested forms", %{form: form} do
+  test "build form data sets nested forms", %{form: form} do
     form_action = "/form"
-    user_data = %{user: %{tag: %{name: "new tag"}}}
+
+    user_data = %{
+      user: %{
+        tag: %{name: "new tag"},
+        friends: %{"0": %{address: %{city: %{zip: "67890"}}}}
+      }
+    }
+
     data = PhoenixIntegration.Requests.test_build_form_data(form, form_action, user_data)
     %{user: user_params} = data
     assert user_params.name == "Initial Name"
@@ -140,6 +147,7 @@ defmodule PhoenixIntegration.FormsTest do
     assert user_params.story == "Initial user story"
     assert user_params.species == "human"
     assert user_params.tag.name == "new tag"
+    assert user_params.friends[:"0"].address.city.zip == "67890"
   end
 
   test "build form raises setting missing field", %{form: form} do

--- a/test/request_test.exs
+++ b/test/request_test.exs
@@ -8,7 +8,7 @@ defmodule PhoenixIntegration.RequestTest do
   #  import IEx
 
   # ============================================================================
-  # set up context 
+  # set up context
   setup do
     %{conn: build_conn(:get, "/")}
   end
@@ -277,7 +277,8 @@ defmodule PhoenixIntegration.RequestTest do
           species: "human",
           story: "Initial user story",
           tag: %{name: "tag"},
-          type: "type_two"
+          type: "type_two",
+          friends: %{"0": %{address: %{city: %{zip: "12345"}}}}
         }
       },
       method: "put"


### PR DESCRIPTION
Currently, the depth of the input name matching is limited to 3 levels, so an input like `user[tags][0][name]` can't be matched. This change makes `PhoenixIntegration.Requests.build_named_value/2` work with arbitrarily nested form fields like `user[friends][0][address][city][zip]`.