### PR TITLE
bump version and update changelist

### DIFF
--- a/changelist.md
+++ b/changelist.md
@@ -1,5 +1,10 @@
 ## phoenix_integration Changelist
 
+### 0.8.0
+  * Fairly large update to handle forms with hidden fields. This update treats forms as parsed
+    trees and has more informative output, and is generally more flexible. This entire update
+    is brought to you by the hard work of Brian Marick (@marick on GitHub). Thank you!
+
 ### 0.7.0
   * __Marking this as 0.7.0 because it is requires a minor version update to Floki. Otherwise
     the actual changes in phoenix_markdown are more patch-like...__

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixIntegration.Mixfile do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
   @url "https://github.com/boydm/phoenix_integration"
 
   def project do


### PR DESCRIPTION
Bump version to 0.8.0 to reflect the work @marick has done to improve the way form trees are parsed and tested.