### PR TITLE
Handle the 8 zillion variants of the `input type="text"` tag.

### DIFF
--- a/lib/phoenix_integration/form/change.ex
+++ b/lib/phoenix_integration/form/change.ex
@@ -1,9 +1,9 @@
 defmodule PhoenixIntegration.Form.Change do
   alias PhoenixIntegration.Form.Common
-  @moduledoc """
-  The test asks that a form value be changed. This struct contains 
-  the information required to make the change.
-  """
+  @moduledoc false
+  
+  # A test asks that a form value be changed. This struct contains 
+  # the information required to make the change.
 
   defstruct path: [], value: nil, ignore_if_missing_from_form: false
 

--- a/lib/phoenix_integration/form/change.ex
+++ b/lib/phoenix_integration/form/change.ex
@@ -9,22 +9,37 @@ defmodule PhoenixIntegration.Form.Change do
 
   def changes(tree), do: changes(tree, %__MODULE__{})
 
-  defp changes(tree, %__MODULE__{} = state) when is_map(tree) do
-    if do_is_struct(tree) do
-      changes(Map.from_struct(tree), note_struct(state))
-    else
-      Enum.flat_map(tree, fn {key, value} ->
-        changes(value, note_longer_path(state, key))
-      end)
-    end 
+  defp changes(node, state) do
+    case classify(node) do
+      :descend_map -> 
+        Enum.flat_map(node, fn {key, value} ->
+          changes(value, note_longer_path(state, key))
+        end)
+      :descend_struct -> 
+        changes(Map.from_struct(node), note_struct(state))
+      :finish_descent -> 
+        finish_descent(node, state)
+    end
   end
 
-  defp changes(value, state) do
+  def classify(node) when not is_map(node),
+    do: :finish_descent
+
+  def classify(node) when is_map(node) do
+    case {do_is_struct(node), node} do
+      {false,              _} -> :descend_map
+      {true,  %Plug.Upload{}} -> :finish_descent
+      {true,               _} -> :descend_struct
+    end
+  end
+    
+  def finish_descent(leaf, state) do 
     [%{state |
        path: Enum.reverse(state.path),
-       value: value
+       value: leaf
       }]
   end
+
 
   # This is in the latest version of Elixir, but let's have
   # some backward compatibility.

--- a/lib/phoenix_integration/form/common.ex
+++ b/lib/phoenix_integration/form/common.ex
@@ -1,7 +1,7 @@
 defmodule PhoenixIntegration.Form.Common do
-  @moduledoc """
-  Code shared among different tree-traversal modules.
-  """
+  @moduledoc false
+
+  ### Code shared among different tree-traversal modules.
   alias PhoenixIntegration.Form.Tag
   
   def symbolize(anything), do: to_string(anything) |> String.to_atom

--- a/lib/phoenix_integration/form/messages.ex
+++ b/lib/phoenix_integration/form/messages.ex
@@ -1,8 +1,7 @@
 defmodule PhoenixIntegration.Form.Messages do
   
-  @moduledoc """
-  The various messages - both warnings and errors - that can be given to the user. 
-  """
+  @moduledoc false
+  # The various messages - both warnings and errors - that can be given to the user. 
   alias PhoenixIntegration.Form.Common
 
   @headlines %{

--- a/lib/phoenix_integration/form/tag.ex
+++ b/lib/phoenix_integration/form/tag.ex
@@ -1,12 +1,11 @@
 defmodule PhoenixIntegration.Form.Tag do
   alias PhoenixIntegration.Form.Common
 
-  @moduledoc """
-  A `Tag` is a representation of a value-providing HTML tag within a
-  Phoenix-style HTML form. Tags live on the leaves of a tree (nested
-  `Map`) representing the whole form. See [DESIGN.md](./DESIGN.md) for
-  more.
-  """
+  @moduledoc false
+  # A `Tag` is a representation of a value-providing HTML tag within a
+  # Phoenix-style HTML form. Tags live on the leaves of a tree (nested
+  # `Map`) representing the whole form. See [DESIGN.md](./DESIGN.md) for
+  # more.
 
   # There are two types of tags.
   #   - some tags are associated with an list of values. Those tags

--- a/lib/phoenix_integration/form/tag.ex
+++ b/lib/phoenix_integration/form/tag.ex
@@ -142,8 +142,8 @@ defmodule PhoenixIntegration.Form.Tag do
   defp apply_input_special_cases(%{type: "radio"} = incomplete_tag, values),
     do: tags_with_checked_attribute(incomplete_tag, values)
 
-  defp apply_input_special_cases(%{type: "text"}, []),
-    do: [""]
+  # This catches the zillion variants of the type="text" tag.
+  defp apply_input_special_cases(_incomplete_tag, []), do: [""]
 
   defp apply_input_special_cases(_incomplete_tag, values), do: values
 

--- a/lib/phoenix_integration/form/tree_creation.ex
+++ b/lib/phoenix_integration/form/tree_creation.ex
@@ -27,7 +27,7 @@ defmodule PhoenixIntegration.Form.TreeCreation do
     form
     |> Floki.find("input")
     |> Enum.map(&force_explicit_type/1)
-    |> filter_types(["text", "checkbox", "hidden", "radio"])
+    |> reject_types(["button", "image", "reset", "submit"])
   end
 
   defp floki_tags(form, "textarea"), do: Floki.find(form, "textarea")
@@ -45,13 +45,13 @@ defmodule PhoenixIntegration.Form.TreeCreation do
     end
   end
 
-  defp filter_types(floki_tags, allowed) do
-    filter_one = fn floki_tag ->
+  defp reject_types(floki_tags, disallowed) do
+    reject_one = fn floki_tag ->
       [type] = Floki.attribute(floki_tag, "type")
-      type in allowed
+      type in disallowed
     end
     
-    Enum.filter(floki_tags, filter_one)
+    Enum.reject(floki_tags, reject_one)
   end 
 
   # ----------------------------------------------------------------------------

--- a/lib/phoenix_integration/form/tree_creation.ex
+++ b/lib/phoenix_integration/form/tree_creation.ex
@@ -1,10 +1,11 @@
 defmodule PhoenixIntegration.Form.TreeCreation do
-  @moduledoc """
-  The code in this module converts a Floki representation of an HTML
-  form into a tree structure whose leaves are Tags: that is, descriptions
-  of a form tag that can provide values to POST-style parameters.
-  See [DESIGN.md](./DESIGN.md) for more.
-  """
+  @moduledoc false
+
+  # The code in this module converts a Floki representation of an HTML
+  # form into a tree structure whose leaves are Tags: that is, descriptions
+  # of a form tag that can provide values to POST-style parameters.
+  # See [DESIGN.md](./DESIGN.md) for more.
+
   alias PhoenixIntegration.Form.Tag
   alias PhoenixIntegration.Form.Common
 

--- a/lib/phoenix_integration/form/tree_edit.ex
+++ b/lib/phoenix_integration/form/tree_edit.ex
@@ -1,9 +1,8 @@
 defmodule PhoenixIntegration.Form.TreeEdit do
-  @moduledoc """
-  Once a tree of `Tag` structures has been created, the values contained
-  within it can be overridden by leaves of a different tree provided by
-  a test.
-  """
+  @moduledoc false
+  # Once a tree of `Tag` structures has been created, the values contained
+  # within it can be overridden by leaves of a different tree provided by
+  # test.
   alias PhoenixIntegration.Form.{Change, Tag, Common}
 
   defstruct valid?: :true, tree: %{}, errors: []

--- a/lib/phoenix_integration/form/tree_finish.ex
+++ b/lib/phoenix_integration/form/tree_finish.ex
@@ -1,8 +1,8 @@
 defmodule PhoenixIntegration.Form.TreeFinish do
-  @moduledoc """
-  Once a tree of `Tag` structures has been created and perhaps edited, 
-  it is converted to a simple tree as delivered to a controller action.
-  """
+  @moduledoc false
+  # Once a tree of `Tag` structures has been created and perhaps edited, 
+  # nit is converted to a simple tree as delivered to a controller action.
+
   alias PhoenixIntegration.Form.Tag
 
   def to_action_params(tree) when is_map(tree) do

--- a/lib/phoenix_integration/requests.ex
+++ b/lib/phoenix_integration/requests.ex
@@ -12,7 +12,7 @@ defmodule PhoenixIntegration.Requests do
   conn each time. The final conn is returned.
 
   All the functions except `follow_path` and `follow_redirect` examine the html
-  conntent of the incoming conn to find a link or form to use. In this way, you
+  content of the incoming conn to find a link or form to use. In this way, you
   can both confirm that content exists in rendered pages and take actions as
   the user would.
 
@@ -171,7 +171,7 @@ defmodule PhoenixIntegration.Requests do
 
   ### Links that don't use the :get method
 
-  When Phoneix.Html renders a link, it usually generates an `<a>` tag. However, if you
+  When Phoenix.Html renders a link, it usually generates an `<a>` tag. However, if you
   specify a method other than :get, then Phoenix generates html looks like a link, but
   is really a form using the method. This is why you must specify the method used in `opts`
   if you used anything other than the standard :get in your link.
@@ -461,11 +461,13 @@ defmodule PhoenixIntegration.Requests do
   ### Parameters
     * `conn` should be a conn returned from a previous request that rendered some html. The
       functions are designed to pass the conn from one call into the next via pipes.
-    * `fields` a map of fields and data to be written into the form before submitting its action. The data can take one of three forms:
+    * `fields` is a map of fields and data to be written into the form before submitting its action. The data can take one of three forms:
       * Most frequently, it's a string.
       * It can be a list of strings. That's used when a set of tags in the form have names ending with `[]` to tell Phoenix to create a list value. See the example below.
-      * It can be an Elixir struct like `DateTime` or [`%Plug.Upload`](https://hexdocs.pm/plug/Plug.Upload.html).
+      * It can be an Elixir struct like `DateTime`.
         In that case, the fields within the struct are used to find matching tags (by name) in the form. Fields that don't match are ignored. See the example below.
+      * If you use [`Plug.Upload`](https://hexdocs.pm/plug/Plug.Upload.html), you can set an `input type="file"` value to the `%Plug.Upload{}` value you'd expect
+        Phoenix to deliver to your controller action. See the example below.
     * `opts` A map of additional options
       * `identifier` indicates which link to find in the html. Defaults to `nil`. Valid values can be
         in the following forms:
@@ -493,6 +495,7 @@ defmodule PhoenixIntegration.Requests do
         get( conn, thing_path(conn, :edit, thing) )
         |> follow_form( %{ thing: %{
             name: "Updated Name",
+            expires: ~D[2011-09-23],
             some_count: 42,
             comments: ["first", "second"],
             photo: upload
@@ -504,7 +507,14 @@ defmodule PhoenixIntegration.Requests do
        <input id="comment1" type="text" name="thing[comments][]" value="">
        <input id="comment2" type="text" name="thing[comments][]" value="">
 
-  The photo part of the form would probably have been created like this:
+  As it happens, the form has tags for only the month and year of the expiration date:
+
+       <select name="thing[expires][year]"> ... </select>
+       <select name="thing[expires][month]"> ... </select>
+
+  ... so the day part of the `Date` is ignored.
+
+  The photo part of the form might have been created like this:
 
        <%= file_input f, :photo %>  
         

--- a/test/details/change_test.exs
+++ b/test/details/change_test.exs
@@ -77,6 +77,25 @@ defmodule PhoenixIntegration.Details.ChangeTest do
     end
   end
 
+
+  # ----------------------------------------------------------------------------
+  describe "special handling of Plug.Upload" do
+    test "it is treated as a single value, not descended into" do 
+      upload = %Plug.Upload{content_type: "image/jpg",
+                            path: "/var/mytests/photo.jpg",
+                            filename: "photo.jpg"}
+    
+      input = %{top_level: %{picture: upload}}
+
+      [only] = Change.changes(input)
+
+      assert_fields(only,
+        path: [:top_level, :picture],
+        value: upload,
+        ignore_if_missing_from_form: false)
+    end
+  end
+
   # ----------------------------------------------------------------------------
   defp sort_by_value(changes) do
     Enum.sort_by(changes, &(to_string &1.value))

--- a/test/details/input_types_test.exs
+++ b/test/details/input_types_test.exs
@@ -1,0 +1,82 @@
+defmodule PhoenixIntegration.RequestTest do
+  use ExUnit.Case
+  use Phoenix.ConnTest, async: true
+  alias PhoenixIntegration.Form.{TreeCreation,TreeEdit,TreeFinish}
+  import PhoenixIntegration.Assertions.Map
+
+  @endpoint PhoenixIntegration.TestEndpoint
+  use PhoenixIntegration
+
+  # Note that input type="checkbox" and type="radio" are checked elsewhere
+  setup do
+    html = get(build_conn(:get, "/"), "/input_types").resp_body
+
+    {:ok, _action, _method, form} =
+      PhoenixIntegration.Requests.test_find_html_form(html, "#input_types", nil, "form")
+
+    created = TreeCreation.build_tree(form)
+    [created: created, tree: created.tree]
+  end
+
+  test "all text-like fields have a value initialized to the empty string",
+    %{tree: tree} do
+    uninitialized_fields = %{user:
+      %{date: "",
+        datetime_local: "",
+        email: "",
+        file: "",
+        hidden: "",
+        month: "",
+        number: "",
+        password: "",
+        photo: "",
+        range: "",
+        search: "",
+        tel: "",
+        text: "",
+        time: "",
+        url: "",
+        week: "",
+        datetime: ""
+      }}
+
+    assert TreeFinish.to_action_params(tree) == uninitialized_fields
+  end
+
+  test "edits apply normally", %{tree: tree} do 
+    edits = %{user:
+      %{date: "date",
+        datetime_local: "datetime_local",
+        email: "email",
+        file: "file",
+        hidden: "hidden",
+        month: "month",
+        number: "number",
+        password: "password",
+        photo: "photo",
+        range: "range",
+        search: "search",
+        tel: "tel",
+        text: "text",
+        time: "time",
+        url: "url",
+        week: "week",
+        datetime: "datetime"
+      }}
+    
+    assert {:ok, edited} = TreeEdit.apply_edits(tree, edits)
+    finished = TreeFinish.to_action_params(edited)
+    assert finished == edits
+  end
+
+  test "explicitly that there are no warnings", %{created: created} do
+    assert created.warnings == []
+  end
+
+  test "explicitly that button-type inputs are not included", %{tree: tree} do
+    refute Map.get(tree.user, :button)
+    refute Map.get(tree.user, :image)
+    refute Map.get(tree.user, :reset)
+    refute Map.get(tree.user, :submit)
+  end
+end  

--- a/test/details/input_types_test.exs
+++ b/test/details/input_types_test.exs
@@ -1,8 +1,7 @@
-defmodule PhoenixIntegration.RequestTest do
+defmodule PhoenixIntegration.Details.InputTypeTest do
   use ExUnit.Case
   use Phoenix.ConnTest, async: true
   alias PhoenixIntegration.Form.{TreeCreation,TreeEdit,TreeFinish}
-  import PhoenixIntegration.Assertions.Map
 
   @endpoint PhoenixIntegration.TestEndpoint
   use PhoenixIntegration

--- a/test/details/tree_edit_test.exs
+++ b/test/details/tree_edit_test.exs
@@ -140,7 +140,35 @@ defmodule PhoenixIntegration.Details.TreeEditTest do
     end
   end
   # ----------------------------------------------------------------------------
+  describe "handling of files" do
+    setup do 
+      tag =
+        """
+        <input type="file" name="top_level[picture]">
+        """ |> input_to_tag
+      [tree: test_tree!([tag])]
+    end
+
+    test "one normally sets a Plug.Upload", %{tree: tree} do
+      upload = %Plug.Upload{content_type: "image/jpg",
+                            path: "/var/mytests/photo.jpg",
+                            filename: "photo.jpg"}
+
+      {:ok, edited} = TreeEdit.apply_edits(tree, %{top_level: %{picture: upload}})
+      assert edited.top_level.picture.values == [upload]
+    end
     
+    test "In case they're not using Plug.Upload, a string is accepted",
+      %{tree: tree} do
+
+      {:ok, edited} = TreeEdit.apply_edits(tree, %{top_level: %{picture: "filename"}})
+      assert edited.top_level.picture.values == ["filename"]
+    end
+  end
+
+  # ----------------------------------------------------------------------------
+
+  
   defp require_ok({:ok, val}), do: val
 
   defp assert_changed(new_tree, old_leaf, changes) do

--- a/test/fixtures/templates/input_types.html
+++ b/test/fixtures/templates/input_types.html
@@ -1,0 +1,38 @@
+<h2>Input types</h2>
+
+<p>
+  Various `input type="xyzzy"` tags operate just like `type="text"`
+  tags so far as this library's code is concerned.
+</p>
+
+
+<form accept-charset="UTF-8" action="/form" method="post" id="input_types">
+  <input name="user[date]" type="date">
+  <input name="user[datetime]" type="datetime">
+  <input name="user[datetime_local]" type="datetime-local">
+  <input name="user[email]" type="email">
+  <input name="user[file]" type="file">
+  <input name="user[hidden]" type="hidden">
+  <input name="user[month]" type="month">
+  <input name="user[number]" type="number">
+  <input name="user[password]" type="password">
+  <input name="user[photo]" type="color">
+  <input name="user[range]" type="range">
+  <input name="user[search]" type="search">
+  <input name="user[tel]" type="tel">
+  <input name="user[text]" type="text">
+  <input name="user[time]" type="time">
+  <input name="user[url]" type="url">
+  <input name="user[week]" type="week">
+
+  <p>
+    The other types of input. (Checkboxes and radio buttons are checked
+    elsewhere.)
+  </p>
+
+  <input name="button" type="button" value="Add to favorites">
+  <input name="image" type="image" src="/media/examples/login-button.png">
+  <input name="reset"  type="reset" value="Reset">
+  <input name="submit" type="submit" value="Send Request">
+
+</form>

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -48,6 +48,12 @@ defmodule PhoenixIntegration.TestEndpoint do
     |> resp(200, File.read!("test/fixtures/templates/checkbox.html"))
   end
 
+  def respond(conn, "GET", "/input_types") do
+    #  <> query
+    pre_get_html(conn, conn_request_path(conn))
+    |> resp(200, File.read!("test/fixtures/templates/input_types.html"))
+  end
+  
   def respond(conn, "GET", _path) do
     pre_get_html(conn, conn_request_path(conn))
     |> resp(200, File.read!("test/fixtures/templates/second.html"))


### PR DESCRIPTION
Fixes #36 

That bug disguised the fact that `input type="file"` wasn't working (because of an interaction between that and using a struct to set multiple values at once). That's also fixed.

Updated the documentation that mentions `Plug.Upload`. 

Prevent the internal `PhoenixIntegration.File.*` modules from appearing in the published documentation.