### PR TITLE
Form Tag: Input name pieces match all non-bracket characters

### DIFF
--- a/lib/phoenix_integration/form/tag.ex
+++ b/lib/phoenix_integration/form/tag.ex
@@ -171,7 +171,7 @@ defmodule PhoenixIntegration.Form.Tag do
     end
   end
 
-  defp separate_name_pieces(name), do: Regex.scan(~r/\w+/, name)
+  defp separate_name_pieces(name), do: Regex.scan(~r/[^\[\]]+/, name)
 
   # Floki allows tags to come in two forms
   defp tag_name([floki_tag]), do: tag_name(floki_tag)


### PR DESCRIPTION
Hi there,

we've started using this wonderful library in another project, where we're using HTML field names with question marks and dashes. These are not recognized properly by PhoenixIntegration as of now.

This PR applies a very loose matching for nested field names, only delimiting them by brackets `[]`.

Hope this also helps others.

Thanks again for this wonderful library! ❤️ 