### PR TITLE
Fail with expected error when RegExp doesn't match

### DIFF
--- a/lib/phoenix_integration/assertions.ex
+++ b/lib/phoenix_integration/assertions.ex
@@ -434,7 +434,7 @@ defmodule PhoenixIntegration.Assertions do
     else
       msg =
         error_msg_type(conn, err_type) <>
-          error_msg_expected("to find \"#{expected}\"") <>
+          error_msg_expected("to find \"#{inspect(expected)}\"") <>
           error_msg_found("Not in the response body\n") <> IO.ANSI.yellow() <> conn.resp_body
 
       raise %ResponseError{message: msg}
@@ -446,7 +446,7 @@ defmodule PhoenixIntegration.Assertions do
     if conn.resp_body =~ expected do
       msg =
         error_msg_type(conn, err_type) <>
-          error_msg_expected("NOT to find \"#{expected}\"") <>
+          error_msg_expected("NOT to find \"#{inspect(expected)}\"") <>
           error_msg_found("in the response body\n") <> IO.ANSI.yellow() <> conn.resp_body
 
       raise %ResponseError{message: msg}

--- a/test/assertions_test.exs
+++ b/test/assertions_test.exs
@@ -238,6 +238,14 @@ defmodule PhoenixIntegration.AssertionsTest do
     end
   end
 
+  test "assert_response :html fails if missing content for regexp", %{conn: conn} do
+    conn = get(conn, "/sample")
+
+    assert_raise PhoenixIntegration.Assertions.ResponseError, fn ->
+      PhoenixIntegration.Assertions.assert_response(conn, html: ~r/invalid content/)
+    end
+  end
+
   # ----------------------------------------------------------------------------
   # assert json
   test "assert_response :json succeeds", %{conn: conn} do


### PR DESCRIPTION
Running test without change to lib shows the error:

```
  1) test assert_response :html fails if missing content for regexp (PhoenixIntegration.AssertionsTest)
     test/assertions_test.exs:241
     Expected exception PhoenixIntegration.Assertions.ResponseError but got Protocol.UndefinedError (protocol String.Chars not implemented for ~r/invalid content/ of type Regex (a struct). This protocol is implemented for the following type(s): Floki.Selector.AttributeSelector, Floki.Selector.Functional, Floki.Selector, Floki.Selector.PseudoClass, Floki.Selector.Combinator, Integer, NaiveDateTime, Time, Date, URI, BitString, DateTime, Version.Requirement, Version, List, Atom, Float)
     code: assert_raise PhoenixIntegration.Assertions.ResponseError, fn ->
     stacktrace:
       (elixir 1.11.3) lib/string/chars.ex:3: String.Chars.impl_for!/1
       (elixir 1.11.3) lib/string/chars.ex:22: String.Chars.to_string/1
       (phoenix_integration 0.9.1) lib/phoenix_integration/assertions.ex:437: PhoenixIntegration.Assertions.assert_body/3
       (elixir 1.11.3) lib/enum.ex:798: Enum."-each/2-lists^foreach/1-0-"/2
       (elixir 1.11.3) lib/enum.ex:798: Enum.each/2
       (phoenix_integration 0.9.1) lib/phoenix_integration/assertions.ex:81: PhoenixIntegration.Assertions.assert_response/2
       test/assertions_test.exs:244: (test)

```

