### PR TITLE
relax dependency phoenix_html to allow version 4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule PhoenixIntegration.Mixfile do
   defp deps do
     [
       {:phoenix, "~> 1.3"},
-      {:phoenix_html, "~> 2.10 or ~> 3.0"},
+      {:phoenix_html, "~> 2.10 or ~> 3.0 or ~> 4.1"},
       {:floki, ">= 0.24.0"},
       {:jason, "~> 1.1"},
       {:flow_assertions, "~> 0.7", only: :test},


### PR DESCRIPTION
Hi there!

Just a quick PR for being able to use Phoenix.HTML v4 🙂